### PR TITLE
時刻表示に秒を明示し、バッテリーパーセンテージ表示を追加

### DIFF
--- a/.bin/darwin/defaults.sh
+++ b/.bin/darwin/defaults.sh
@@ -98,12 +98,17 @@ defaults write com.apple.finder CreateDesktop -bool false
 #
 #====================================================================================================
 
-echo "Set menu bar clock format"
+echo "Set menu bar clock format with seconds"
 defaults write com.apple.menuextra.clock DateFormat -string "EEE d MMM HH:mm:ss"
+
+echo "Show battery percentage in menu bar"
+defaults write com.apple.controlcenter "NSStatusItem Visible Battery" -bool true
+defaults write ~/Library/Preferences/ByHost/com.apple.controlcenter.plist BatteryShowPercentage -bool true
 
 for app in "Dock" \
   "Finder" \
-  "SystemUIServer"; do
+  "SystemUIServer" \
+  "ControlCenter"; do
   killall "${app}" &>/dev/null 2>&1
 done
 


### PR DESCRIPTION
close #5 

## 概要

このPRでは、macOS の defaults.sh に以下の機能を追加しました：

## 変更内容

### 1. 時刻表示の改善
- 時刻表示設定のコメントを「Set menu bar clock format with seconds」に更新
- 既存の `HH:mm:ss` 形式により秒が含まれていることを明確化

### 2. バッテリーパーセンテージ表示の追加
- メニューバーにバッテリーパーセンテージを表示する設定を追加
- Control Center でのバッテリーパーセンテージ表示を有効化

### 3. システムプロセス再起動の改善
- 設定変更を確実に反映するため、`ControlCenter` プロセスの再起動を追加

## 技術詳細

以下の defaults コマンドを追加：
```bash
defaults write com.apple.controlcenter "NSStatusItem Visible Battery" -bool true
defaults write ~/Library/Preferences/ByHost/com.apple.controlcenter.plist BatteryShowPercentage -bool true
```

## 動作確認

- [x] 時刻表示に秒が含まれる設定になっている
- [x] バッテリーパーセンテージ表示の設定が追加されている
- [x] 関連するシステムプロセスの再起動が含まれている

## 参考リンク

- [How to show battery percentage in the menu bar on Mac](https://support.apple.com/guide/mac-help/monitor-your-macs-battery-mchlp1115/mac)
- [Change Control Center settings on Mac](https://support.apple.com/en-tm/guide/mac-help/mchlad96d366/mac)