### PR TITLE
Zoom バーチャル背景画像をダウンロードするスクリプトを追加 (#13)

### DIFF
--- a/.bin/darwin/zoom_backgrounds.sh
+++ b/.bin/darwin/zoom_backgrounds.sh
@@ -1,0 +1,76 @@
+#!/bin/zsh
+
+echo "Start zoom_backgrounds.sh"
+
+if [ "$(uname)" != "Darwin" ]; then
+  echo "This script is only for macOS"
+  exit 1
+fi
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+URLS_FILE="${SCRIPT_DIR}/zoom_backgrounds.txt"
+DEST_DIR="${ZOOM_BG_DIR:-${HOME}/Pictures/ZoomBackgrounds}"
+
+mkdir -p "${DEST_DIR}"
+echo "保存先: ${DEST_DIR}"
+
+if [ ! -f "${URLS_FILE}" ]; then
+  echo "URL リスト ${URLS_FILE} が存在しないためスキップします"
+  echo "End zoom_backgrounds.sh"
+  echo "----------------------------------------"
+  exit 0
+fi
+
+if ! command -v wget >/dev/null 2>&1; then
+  echo "wget が見つかりません。brew bundle 経由で wget をインストールしてください"
+  exit 1
+fi
+
+downloaded=0
+skipped=0
+failed=0
+
+while IFS= read -r raw_line || [ -n "${raw_line}" ]; do
+  # 前後の空白を削る
+  line="${raw_line#"${raw_line%%[![:space:]]*}"}"
+  line="${line%"${line##*[![:space:]]}"}"
+
+  # 空行・コメント行はスキップ
+  [ -z "${line}" ] && continue
+  case "${line}" in
+    \#*) continue ;;
+  esac
+
+  filename="${line##*/}"
+  filename="${filename%%\?*}"
+  if [ -z "${filename}" ]; then
+    echo "ファイル名を URL から取り出せませんでした: ${line}"
+    failed=$((failed + 1))
+    continue
+  fi
+
+  target="${DEST_DIR}/${filename}"
+  if [ -f "${target}" ]; then
+    echo "既に存在するためスキップ: ${filename}"
+    skipped=$((skipped + 1))
+    continue
+  fi
+
+  echo "ダウンロード: ${filename}"
+  if wget --quiet --show-progress --output-document="${target}" "${line}"; then
+    downloaded=$((downloaded + 1))
+  else
+    echo "ダウンロード失敗: ${line}"
+    rm -f "${target}"
+    failed=$((failed + 1))
+  fi
+done < "${URLS_FILE}"
+
+echo "結果: 新規 ${downloaded} 件 / スキップ ${skipped} 件 / 失敗 ${failed} 件"
+
+# Zoom のバーチャル背景ディレクトリへのシンボリックリンクは Zoom の実装に依存するため案内のみに留める
+echo ""
+echo "Zoom アプリの「バーチャル背景」設定画面で ${DEST_DIR} 配下の画像を選択してください。"
+
+echo "End zoom_backgrounds.sh"
+echo "----------------------------------------"

--- a/.bin/darwin/zoom_backgrounds.sh
+++ b/.bin/darwin/zoom_backgrounds.sh
@@ -15,7 +15,16 @@ mkdir -p "${DEST_DIR}"
 echo "保存先: ${DEST_DIR}"
 
 if [ ! -f "${URLS_FILE}" ]; then
-  echo "URL リスト ${URLS_FILE} が存在しないためスキップします"
+  cat <<EOF
+URL リスト ${URLS_FILE} が存在しないためスキップします。
+ダウンロードしたい場合は、以下のフォーマットで作成してください:
+
+  # 行頭の # はコメント、空行は無視されます
+  https://example.com/zoom-bg/space.jpg
+  https://example.com/zoom-bg/forest.png
+
+(個人 URL を含むため .gitignore で管理対象外にしています)
+EOF
   echo "End zoom_backgrounds.sh"
   echo "----------------------------------------"
   exit 0

--- a/.bin/darwin/zoom_backgrounds.txt
+++ b/.bin/darwin/zoom_backgrounds.txt
@@ -1,8 +1,0 @@
-# Zoom バーチャル背景としてダウンロードしたい画像 URL を 1 行ずつ記述する。
-# 行頭の # はコメントとして扱われ、空行は無視される。
-# Google Photos の共有アルバムは認証なしで個別画像 URL を取得できないため、
-# 直リンク (例: https://example.com/zoom-bg/space.jpg) を貼ること。
-#
-# 例:
-# https://example.com/zoom-bg/space.jpg
-# https://example.com/zoom-bg/forest.png

--- a/.bin/darwin/zoom_backgrounds.txt
+++ b/.bin/darwin/zoom_backgrounds.txt
@@ -1,0 +1,8 @@
+# Zoom バーチャル背景としてダウンロードしたい画像 URL を 1 行ずつ記述する。
+# 行頭の # はコメントとして扱われ、空行は無視される。
+# Google Photos の共有アルバムは認証なしで個別画像 URL を取得できないため、
+# 直リンク (例: https://example.com/zoom-bg/space.jpg) を貼ること。
+#
+# 例:
+# https://example.com/zoom-bg/space.jpg
+# https://example.com/zoom-bg/forest.png

--- a/.gitignore
+++ b/.gitignore
@@ -204,3 +204,6 @@ WhiteSur-icon-theme
 .bin/darwin/.codex/tmp/
 .bin/darwin/.codex/vendor_imports/
 .bin/darwin/.codex/version.json
+
+### dotfiles local config
+.bin/darwin/zoom_backgrounds.txt

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ help:
 	@echo "  link      : link スクリプトを実行します。"
 	@echo "  defaults  : defaults スクリプトを実行します。"
 	@echo "  cobalt2   : cobalt2 テーマのセットアップを実行します。"
+	@echo "  zoom-bg   : Zoom バーチャル背景画像を一括ダウンロードします。"
 	@echo ""
 	@echo "注意事項:"
 	@echo "  - ターゲットを指定しない場合、help ターゲットが実行されます。"
@@ -25,6 +26,7 @@ help:
 	@echo "  make link      : link スクリプトを実行します。"
 	@echo "  make defaults  : defaults スクリプトを実行します。"
 	@echo "  make cobalt2   : cobalt2 テーマのセットアップを実行します。"
+	@echo "  make zoom-bg   : Zoom バーチャル背景画像を一括ダウンロードします。"
 
 .PHONY: all
 all:
@@ -53,6 +55,11 @@ defaults:
 .PHONY: cobalt2
 cobalt2:
 	.bin/darwin/cobalt2.sh
+
+# Zoom バーチャル背景画像を .bin/darwin/zoom_backgrounds.txt の URL から一括ダウンロードする
+.PHONY: zoom-bg
+zoom-bg:
+	.bin/darwin/zoom_backgrounds.sh
 
 # ------------------------------------------------------------------------------
 # Test environment related commands and comments


### PR DESCRIPTION
## Summary
- `.bin/darwin/zoom_backgrounds.sh` を新規追加し、URL リスト経由で Zoom バーチャル背景画像を一括ダウンロード
- ダウンロード対象 URL は `.bin/darwin/zoom_backgrounds.txt` に 1 行ずつ記述する（コメント・空行をサポート）
- `Makefile` に `make zoom-bg` ターゲットを追加（`make all` には含めない）

## Behavior
- 保存先は `${ZOOM_BG_DIR:-~/Pictures/ZoomBackgrounds}`
- 既存ファイルは上書きせずスキップするため再実行可能
- `wget` が未インストールの場合は brew bundle 経由でのインストールを促す

## Test Plan
- [ ] `.bin/darwin/zoom_backgrounds.txt` を空のまま `make zoom-bg` 実行 → 何もダウンロードされず正常終了
- [ ] URL を 1 件追加 → 当該画像が `~/Pictures/ZoomBackgrounds/` に保存される
- [ ] 再度 `make zoom-bg` 実行 → 既存ファイルがスキップされる

Closes #13