### PR TITLE
通知を OFF にするデフォルト設定を defaults.sh に追加 (#14)

### DIFF
--- a/.bin/darwin/defaults.sh
+++ b/.bin/darwin/defaults.sh
@@ -105,10 +105,29 @@ echo "Show battery percentage in menu bar"
 defaults write com.apple.controlcenter "NSStatusItem Visible Battery" -bool true
 defaults write ~/Library/Preferences/ByHost/com.apple.controlcenter.plist BatteryShowPercentage -bool true
 
+#====================================================================================================
+#
+# Notifications
+#
+# macOS のバージョンによっては存在しないキーがあるため、個別の失敗はセットアップ全体を止めない。
+# アプリ単位の通知 OFF は System Settings → Notifications で個別対応する。
+#
+#====================================================================================================
+
+echo "Show Focus modes pill in Control Center menu bar"
+defaults write com.apple.controlcenter "FocusModes" -bool true 2>/dev/null || true
+
+echo "Hide notification previews on the lock screen"
+defaults write com.apple.notificationcenterui "WhenLocked" -int 0 2>/dev/null || true
+
+echo "Shorten notification banner display time"
+defaults write com.apple.notificationcenterui bannerTime -int 1 2>/dev/null || true
+
 for app in "Dock" \
   "Finder" \
   "SystemUIServer" \
-  "ControlCenter"; do
+  "ControlCenter" \
+  "NotificationCenter"; do
   killall "${app}" &>/dev/null 2>&1
 done
 


### PR DESCRIPTION
## Summary
- `.bin/darwin/defaults.sh` のメニューバーセクション下に「通知」セクションを新設
- 集中モード (Focus) をメニューバーに常時表示し、ロック画面での通知プレビューを非表示、バナー表示時間を短縮
- `killall` ループに `NotificationCenter` を追加して即時反映

## Compatibility
- macOS のバージョン（Ventura / Sonoma / Sequoia）でキー名が変わる可能性があるため、追加した `defaults write` には `|| true` を付けて、個別失敗がセットアップ全体を止めないようにした
- アプリ単位の通知 OFF までは System Settings → Notifications での個別対応となる

## Test Plan
- [ ] `make defaults` がエラーなく完走する
- [ ] メニューバーに集中モードアイコンが表示される（実機）
- [ ] ロック画面で通知プレビューが非表示になる（実機）

Closes #14