### PR TITLE
SSH 鍵生成→クリップボードコピーを行う初期化スクリプトを追加 (#15)

### DIFF
--- a/.bin/darwin/ssh_keygen.sh
+++ b/.bin/darwin/ssh_keygen.sh
@@ -1,0 +1,49 @@
+#!/bin/zsh
+
+set -u
+
+echo "Start ssh_keygen.sh"
+
+if [ "$(uname)" != "Darwin" ]; then
+  echo "This script is only for macOS"
+  exit 1
+fi
+
+KEY_TYPE="ed25519"
+KEY_PATH="${HOME}/.ssh/id_${KEY_TYPE}"
+
+# コメント（メールアドレス）の決定: 引数 > git config > USER@HOST
+if [ "$#" -ge 1 ] && [ -n "$1" ]; then
+  COMMENT="$1"
+elif command -v git >/dev/null 2>&1 && git config --global user.email >/dev/null 2>&1; then
+  COMMENT="$(git config --global user.email)"
+fi
+COMMENT="${COMMENT:-${USER}@$(hostname)}"
+
+# ~/.ssh を 700 で作成
+mkdir -p "${HOME}/.ssh"
+chmod 700 "${HOME}/.ssh"
+
+if [ -f "${KEY_PATH}" ]; then
+  echo "既に ${KEY_PATH} が存在するため生成をスキップします"
+else
+  echo "ssh-keygen -t ${KEY_TYPE} -C \"${COMMENT}\" -f ${KEY_PATH}"
+  ssh-keygen -t "${KEY_TYPE}" -C "${COMMENT}" -f "${KEY_PATH}" -N ""
+  chmod 600 "${KEY_PATH}"
+  chmod 644 "${KEY_PATH}.pub"
+fi
+
+# 公開鍵をクリップボードへ
+if command -v pbcopy >/dev/null 2>&1; then
+  pbcopy < "${KEY_PATH}.pub"
+  echo "公開鍵 (${KEY_PATH}.pub) をクリップボードにコピーしました"
+else
+  echo "pbcopy が見つからないためクリップボードコピーをスキップしました"
+fi
+
+echo "----- 公開鍵 -----"
+cat "${KEY_PATH}.pub"
+echo "------------------"
+
+echo "End ssh_keygen.sh"
+echo "----------------------------------------"

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ help:
 	@echo "  link      : link スクリプトを実行します。"
 	@echo "  defaults  : defaults スクリプトを実行します。"
 	@echo "  cobalt2   : cobalt2 テーマのセットアップを実行します。"
+	@echo "  ssh-key   : ed25519 鍵を生成し、公開鍵をクリップボードにコピーします。"
 	@echo ""
 	@echo "注意事項:"
 	@echo "  - ターゲットを指定しない場合、help ターゲットが実行されます。"
@@ -25,6 +26,7 @@ help:
 	@echo "  make link      : link スクリプトを実行します。"
 	@echo "  make defaults  : defaults スクリプトを実行します。"
 	@echo "  make cobalt2   : cobalt2 テーマのセットアップを実行します。"
+	@echo "  make ssh-key   : ed25519 鍵を生成し、公開鍵をクリップボードにコピーします。"
 
 .PHONY: all
 all:
@@ -53,6 +55,11 @@ defaults:
 .PHONY: cobalt2
 cobalt2:
 	.bin/darwin/cobalt2.sh
+
+# ed25519 鍵を生成し、公開鍵をクリップボードへコピーする
+.PHONY: ssh-key
+ssh-key:
+	.bin/darwin/ssh_keygen.sh
 
 # ------------------------------------------------------------------------------
 # Test environment related commands and comments


### PR DESCRIPTION
## Summary
- `.bin/darwin/ssh_keygen.sh` を新規追加し、ed25519 鍵生成と公開鍵のクリップボードコピーを自動化
- `Makefile` に `make ssh-key` ターゲットを追加（`make all` には含めない）

## Behavior
- `~/.ssh` を 700 で作成（無ければ）
- `~/.ssh/id_ed25519` が既に存在する場合は上書きせずスキップ
- 公開鍵コメント (`-C`) は 引数 > `git config --global user.email` > `${USER}@$(hostname)` の優先順位で決定
- 生成完了後、`pbcopy < ~/.ssh/id_ed25519.pub` でクリップボードにコピー
- 標準出力にも公開鍵を表示

## Test Plan
- [ ] 既存鍵がある環境で `make ssh-key` を実行 → 上書きせずクリップボードへコピー
- [ ] `~/.ssh` を空にした実機で `make ssh-key` を実行 → ed25519 鍵が生成され、パーミッションが 600/644 になる

Closes #15