### PR TITLE
メニューバーに Bluetooth を常時表示する設定を defaults.sh に追加 (#16)

### DIFF
--- a/.bin/darwin/defaults.sh
+++ b/.bin/darwin/defaults.sh
@@ -105,6 +105,9 @@ echo "Show battery percentage in menu bar"
 defaults write com.apple.controlcenter "NSStatusItem Visible Battery" -bool true
 defaults write ~/Library/Preferences/ByHost/com.apple.controlcenter.plist BatteryShowPercentage -bool true
 
+echo "Show Bluetooth in menu bar"
+defaults write com.apple.controlcenter "NSStatusItem Visible Bluetooth" -bool true
+
 for app in "Dock" \
   "Finder" \
   "SystemUIServer" \


### PR DESCRIPTION
## Summary
- `.bin/darwin/defaults.sh` の menu bar セクション（バッテリー設定の直後）に Bluetooth を常時表示する `NSStatusItem Visible Bluetooth` 設定を追加
- 既存の `killall ControlCenter` ループで設定が即時反映される

## Background
- #1 のフィードバックで「メニューバーに Bluetooth を表示」要望が残っていた
- バッテリー% (#5) と同じパターン (`NSStatusItem Visible <Module>`) で実装

## Test Plan
- [ ] `make defaults` がエラーなく完走する
- [ ] 実機でメニューバーに Bluetooth アイコンが表示される

Closes #16