### PR TITLE
Caps Lock と Control キーを入れ替える仕組みを追加

### DIFF
--- a/.bin/darwin/defaults.sh
+++ b/.bin/darwin/defaults.sh
@@ -126,6 +126,18 @@ defaults write com.apple.notificationcenterui "WhenLocked" -int 0 2>/dev/null ||
 echo "Shorten notification banner display time"
 defaults write com.apple.notificationcenterui bannerTime -int 1 2>/dev/null || true
 
+#====================================================================================================
+#
+# Keyboard
+#
+# Caps Lock <-> Left Control を入れ替える。再起動を跨いで永続化する場合は
+# System Settings → Keyboard → Modifier Keys でも同じ設定をしておくこと。
+#
+#====================================================================================================
+
+echo "Swap Caps Lock and Left Control (current session)"
+hidutil property --set '{"UserKeyMapping":[{"HIDKeyboardModifierMappingSrc":0x700000039,"HIDKeyboardModifierMappingDst":0x7000000E0},{"HIDKeyboardModifierMappingSrc":0x7000000E0,"HIDKeyboardModifierMappingDst":0x700000039}]}' >/dev/null || true
+
 for app in "Dock" \
   "Finder" \
   "SystemUIServer" \


### PR DESCRIPTION
## Summary
- `.bin/darwin/defaults.sh` の Keyboard セクションに `hidutil property --set UserKeyMapping` のワンライナーを追加し、Caps Lock ↔ Left Control を入れ替える
- 旧版で含めていた LaunchAgent 生成、専用シェルスクリプト、`make swap-keys` ターゲットは撤廃し、最小実装に縮小

## Persistence
- `hidutil` は現セッション (ログイン中) で有効。再起動を跨いで完全に永続化したい場合は **System Settings → Keyboard → Modifier Keys** で同じ入れ替えを 1 度設定する運用とする (この PR ではそこまで自動化しない)
- `make defaults` を再ログイン後に流せばその場で再適用される
- 実行失敗を想定して `|| true` 付き

## キーコード
- Caps Lock: `0x700000039`
- Left Control: `0x7000000E0`

## Test Plan
- [ ] 実機で `make defaults` を実行 → 直後に Caps Lock が Control として動作する
- [ ] System Settings の Modifier Keys 設定も行えばログアウト跨ぎでも維持される